### PR TITLE
Added path parameter, renamed params [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8.27.4
+  orb-tools: circleci/orb-tools@9.0.0
   cli: circleci/circleci-cli@0.1.4
 
 jobs:
@@ -31,9 +31,8 @@ workflows:
                 - master
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: signavio/aws-ecr-eks
-          orb-path: src/@orb.yml
-          segment: minor
           checkout: true
+          add-pr-comment: true
           publish-token-variable: CIRCLECI_TOKEN
           publish-version-tag: false
           fail-if-semver-not-indicated: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,15 +29,16 @@ workflows:
             branches:
               ignore:
                 - master
-      - orb-tools/increment:
-          orb-ref: signavio/aws-ecr-eks
+      - orb-tools/dev-promote-prod-from-commit-subject:
+          orb-name: signavio/aws-ecr-eks
           orb-path: src/@orb.yml
           checkout: true
           publish-token-variable: CIRCLECI_TOKEN
+          publish-version-tag: false
+          fail-if-semver-not-indicated: false
           requires:
             - orb-tools/lint
             - validate
           filters:
             branches:
-              only:
-                - master
+              only: master

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Remember to include the `[semver:FOO]` pattern the pull request name, where `FOO` is `major`, `minor`, `patch`, or `skip` (to skip promotion).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # aws-ecr-argocd-orb
-CircleCi Orb to build and push to AWS ECR and deploy to EKS via kubectl rollout restart 
+
+CircleCi Orb to build and push to AWS ECR and deploy to EKS via kubectl rollout restart
+
+## Development
+
+When submitting your changes as a pull request, the CI pipeline will automatically trigger a dev release of the orb.
+
+After merging a PR, there is an automatic production release.
+To define new semver version of the release make sure to include the `[semver:FOO]` pattern in the merge commit message, where `FOO` is `major`, `minor`, `patch`, or `skip` (to skip promotion).

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -78,6 +78,10 @@ jobs:
         description: Dockerfile name
         type: string
         default: Dockerfile
+      path:
+        description: Path to the directory containing your Dockerfile and build context.
+        type: string
+        default: .
 
     machine:
       image: ubuntu-1604:201903-01
@@ -86,6 +90,7 @@ jobs:
       - aws-ecr/build-and-push-image:
           attach-workspace: true
           repo: <<parameters.ecr_repo>>
+          path: <<parameters.path>>
           tag: <<parameters.tags>>
           dockerfile: <<parameters.dockerfile>>
       - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -38,7 +38,7 @@ jobs:
       repo:
         description: The ecr repo to push the docker images.
         type: string
-      tags:
+      tag:
         description: |
           The docker images tag to be applied.
           (defaults to latest,${CIRCLE_SHA1})

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,7 +8,7 @@ description: |
   Source code: https://github.com/signavio/circleci-aws-ecr-eks-orb
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.4.0
+  aws-ecr: circleci/aws-ecr@6.7.0
 
 executors:
   default:
@@ -35,7 +35,7 @@ jobs:
         description: executor to use for this job
         type: executor
         default: default
-      ecr_repo:
+      repo:
         description: The ecr repo to push the docker images.
         type: string
       tags:
@@ -89,9 +89,9 @@ jobs:
       - aws-ecr/ecr-login-for-secondary-account
       - aws-ecr/build-and-push-image:
           attach-workspace: true
-          repo: <<parameters.ecr_repo>>
+          repo: <<parameters.repo>>
           path: <<parameters.path>>
-          tag: <<parameters.tags>>
+          tag: <<parameters.tag>>
           dockerfile: <<parameters.dockerfile>>
       - run:
           name: "Install tools"
@@ -147,5 +147,5 @@ examples:
             - build-push-restart:
                 context: ecr
                 attach-workspace: true
-                ecr_repo: myecrrepo
+                repo: myecrrepo
                 deployment_name: mydeployment


### PR DESCRIPTION
This PR introduces a BREAKING CHANGE to keep parameter names consistent with the wrapped `circleci/aws-ecr` orb.

- param `ecr_repo` has been renamed to `repo`
- param `tags` has been renamed to `tag`
- param `path` has been added to define the Docker build context
- updated to latest version of `circleci/aws-ecr` orb