### PR TITLE
Correct naming scheme for extra build args parameter [semver:minor]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -86,7 +86,7 @@ jobs:
         description: Path to the directory containing your Dockerfile and build context.
         type: string
         default: .
-      extra-build-args:
+      extra_build_args:
         description: Additional arguments to pass to the Docker build step
         type: string
         default: ""

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -101,7 +101,7 @@ jobs:
           path: <<parameters.path>>
           tag: <<parameters.tag>>
           dockerfile: <<parameters.dockerfile>>
-          extra-build-args: <<parameters.extra-build-args>>
+          extra-build-args: <<parameters.extra_build_args>>
       - run:
           name: "Install tools"
           command: |


### PR DESCRIPTION
Use consistent naming scheme for recently introduced parameter.