### PR TITLE
[semver:minor] Add support for Docker Buildkit

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -29,7 +29,8 @@ jobs:
       Uses circleci/aws-ecr to build and publish the docker images.
       Runs kubectl rollout restart deployment/NAME afterwards to refresh the latest tag on cluster.
     executor: <<parameters.executor>>
-
+    environment:
+      DOCKER_BUILDKIT: "1"
     parameters:
       executor:
         description: executor to use for this job


### PR DESCRIPTION
In order to use [Docker's buildkit feature](https://docs.docker.com/develop/develop-images/build_enhancements/), the build environment needs to set the `DOCKER_BUILDKIT` environment variable ([Example](https://github.com/CircleCI-Public/aws-ecr-orb/issues/77)). This PR enables this feature for the `build-push-restart` job.
