### PR TITLE
[semver:minor] Use circleci/aws-ecr@8.0.0 orb

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -91,13 +91,29 @@ jobs:
         description: Additional arguments to pass to the Docker build step
         type: string
         default: ""
+      attach_workspace:
+        type: boolean
+        default: true
+        description: >
+          Boolean for whether or not to attach to an existing workspace. Default
+          is true.
+      workspace_root:
+        type: string
+        default: "."
+        description: >
+          Workspace root path that is either an absolute path or a path relative
+          to the working directory. Defaults to '.' (the working directory)
 
     machine:
       image: ubuntu-2004:202010-01
     steps:
+      - when:
+        condition: <<parameters.attach_workspace>>
+        steps:
+          - attach_workspace:
+              at: <<parameters.workspace_root>>
       - aws-ecr/ecr-login
       - aws-ecr/build-image:
-          attach-workspace: true
           repo: <<parameters.repo>>
           path: <<parameters.path>>
           tag: <<parameters.tag>>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -96,13 +96,14 @@ jobs:
       image: ubuntu-2004:202010-01
     steps:
       - aws-ecr/ecr-login
-      - aws-ecr/build-and-push-image:
+      - aws-ecr/build-image:
           attach-workspace: true
           repo: <<parameters.repo>>
           path: <<parameters.path>>
           tag: <<parameters.tag>>
           dockerfile: <<parameters.dockerfile>>
           extra-build-args: <<parameters.extra_build_args>>
+          push-image: true
       - run:
           name: "Install tools"
           command: |

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,7 +8,7 @@ description: |
   Source code: https://github.com/signavio/circleci-aws-ecr-eks-orb
 
 orbs:
-  aws-ecr: circleci/aws-ecr@7.0.0
+  aws-ecr: circleci/aws-ecr@8.0.0
 
 executors:
   default:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -108,10 +108,10 @@ jobs:
       image: ubuntu-2004:202010-01
     steps:
       - when:
-        condition: <<parameters.attach_workspace>>
-        steps:
-          - attach_workspace:
-              at: <<parameters.workspace_root>>
+          condition: <<parameters.attach_workspace>>
+          steps:
+            - attach_workspace:
+                at: <<parameters.workspace_root>>
       - aws-ecr/ecr-login
       - aws-ecr/build-image:
           repo: <<parameters.repo>>


### PR DESCRIPTION
Version 8.0.0 has an improved `docker buildx` mechanism and should support Docker build secrets out of the box. More details can be found in the [release notes](https://github.com/CircleCI-Public/aws-ecr-orb/pull/172).

Changes in this PR:
* Use new `build-image` command instead of deprecated `build-and-push-image`
* Add `attach_workspace` and `workspace_root` parameters