### PR TITLE
[semvar:minor] Add build-push job

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -15,16 +15,113 @@ executors:
   default:
     description: |
       Container to run the steps.
-
     parameters:
       image:
         type: string
         default: ubuntu-2204:current
-
     machine:
       image: <<parameters.image>>
 
 jobs:
+  build-push:
+    description: >
+      Uses circleci/aws-ecr to build and publish the docker images.
+    executor: <<parameters.executor>>
+    environment:
+      DOCKER_BUILDKIT: "1"
+    parameters:
+      executor:
+        description: executor to use for this job
+        type: executor
+        default: default
+      repo:
+        description: The ecr repo to push the docker images.
+        type: string
+      tag:
+        description: |
+          The docker images tag to be applied.
+          (defaults to latest,${CIRCLE_SHA1})
+        type: string
+        default: "latest,${CIRCLE_SHA1}"
+      eks_account_id:
+        description: |
+          Env var of the account id of the EKS cluster containing the deployment
+          (default EKS_ACCOUNT_ID)
+        type: env_var_name
+        default: EKS_ACCOUNT_ID
+      role_in_target_account:
+        description: |
+          Env var of the name of the role to be assumed to update the kubeconfig
+          (defaults to ASSUME_ROLE)
+        type: env_var_name
+        default: ASSUME_ROLE
+      aws_region:
+        description: |
+          Env var of AWS region to operate in
+          (defaults to AWS_REGION)
+        type: env_var_name
+        default: AWS_REGION
+      eks_cluster_name:
+        description: |
+          Env var of EKS cluster name
+          (defaults to EKS_NAME)
+        type: env_var_name
+        default: EKS_NAME
+      dockerfile:
+        description: Dockerfile name
+        type: string
+        default: Dockerfile
+      path:
+        description: Path to the directory containing your Dockerfile.
+        type: string
+        default: .
+      build_path:
+        description: Path to the directory containing your build context.
+        type: string
+        default: .
+      extra_build_args:
+        description: Additional arguments to pass to the Docker build step
+        type: string
+        default: ""
+      attach_workspace:
+        type: boolean
+        default: true
+        description: >
+          Boolean for whether or not to attach to an existing workspace. Default
+          is true.
+      workspace_root:
+        type: string
+        default: "."
+        description: >
+          Workspace root path that is either an absolute path or a path relative
+          to the working directory. Defaults to '.' (the working directory)
+      platform:
+        type: string
+        default: "linux/amd64"
+        description: >
+          String to specify the architecture of the base image
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - aws-cli/setup:
+          profile_name: global_res
+      - aws-ecr/ecr_login:
+          profile_name: global_res
+      - aws-ecr/build_and_push_image:
+          attach_workspace: <<parameters.attach_workspace>>
+          workspace_root: <<parameters.workspace_root>>
+          auth:
+            - aws-cli/setup:
+                profile_name: global_res
+          profile_name: global_res
+          repo: <<parameters.repo>>
+          path: <<parameters.path>>
+          build_path: <<parameters.build_path>>
+          tag: <<parameters.tag>>
+          dockerfile: <<parameters.dockerfile>>
+          extra_build_args: <<parameters.extra_build_args>>
+          platform: <<parameters.platform>>
+
   build-push-restart:
     description: >
       Uses circleci/aws-ecr to build and publish the docker images.
@@ -113,7 +210,6 @@ jobs:
         default: "linux/amd64"
         description: >
           String to specify the architecture of the base image
-
     machine:
       image: ubuntu-2204:current
     steps:
@@ -181,14 +277,27 @@ jobs:
             fi
 
 examples:
+  build-push-staging:
+    description:
+    usage:
+      version: 2.1
+      orbs:
+        aws-ecr-eks: signavio/aws-ecr-eks@x.y
+      workflows:
+        version: 2
+        aws-ecr-eks:
+          jobs:
+            - build-push-restart:
+                context: ecr
+                repo: myecrrepo
+                deployment_name: mydeployment
+
   build-push-restart-staging:
     description:
     usage:
       version: 2.1
-
       orbs:
         aws-ecr-eks: signavio/aws-ecr-eks@x.y
-
       workflows:
         version: 2
         aws-ecr-eks:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -43,30 +43,6 @@ jobs:
           (defaults to latest,${CIRCLE_SHA1})
         type: string
         default: "latest,${CIRCLE_SHA1}"
-      eks_account_id:
-        description: |
-          Env var of the account id of the EKS cluster containing the deployment
-          (default EKS_ACCOUNT_ID)
-        type: env_var_name
-        default: EKS_ACCOUNT_ID
-      role_in_target_account:
-        description: |
-          Env var of the name of the role to be assumed to update the kubeconfig
-          (defaults to ASSUME_ROLE)
-        type: env_var_name
-        default: ASSUME_ROLE
-      aws_region:
-        description: |
-          Env var of AWS region to operate in
-          (defaults to AWS_REGION)
-        type: env_var_name
-        default: AWS_REGION
-      eks_cluster_name:
-        description: |
-          Env var of EKS cluster name
-          (defaults to EKS_NAME)
-        type: env_var_name
-        default: EKS_NAME
       dockerfile:
         description: Dockerfile name
         type: string
@@ -121,7 +97,6 @@ jobs:
           dockerfile: <<parameters.dockerfile>>
           extra_build_args: <<parameters.extra_build_args>>
           platform: <<parameters.platform>>
-
   build-push-restart:
     description: >
       Uses circleci/aws-ecr to build and publish the docker images.
@@ -131,6 +106,30 @@ jobs:
       DOCKER_BUILDKIT: "1"
     parameters:
       <<: *build-push-parameters
+      eks_account_id:
+        description: |
+          Env var of the account id of the EKS cluster containing the deployment
+          (default EKS_ACCOUNT_ID)
+        type: env_var_name
+        default: EKS_ACCOUNT_ID
+      role_in_target_account:
+        description: |
+          Env var of the name of the role to be assumed to update the kubeconfig
+          (defaults to ASSUME_ROLE)
+        type: env_var_name
+        default: ASSUME_ROLE
+      aws_region:
+        description: |
+          Env var of AWS region to operate in
+          (defaults to AWS_REGION)
+        type: env_var_name
+        default: AWS_REGION
+      eks_cluster_name:
+        description: |
+          Env var of EKS cluster name
+          (defaults to EKS_NAME)
+        type: env_var_name
+        default: EKS_NAME
       deployment_name:
         description: Name of the deployment to restart
         type: string

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -29,7 +29,7 @@ jobs:
     executor: <<parameters.executor>>
     environment:
       DOCKER_BUILDKIT: "1"
-    parameters:
+    parameters: &build-push-parameters
       executor:
         description: executor to use for this job
         type: executor
@@ -130,43 +130,7 @@ jobs:
     environment:
       DOCKER_BUILDKIT: "1"
     parameters:
-      executor:
-        description: executor to use for this job
-        type: executor
-        default: default
-      repo:
-        description: The ecr repo to push the docker images.
-        type: string
-      tag:
-        description: |
-          The docker images tag to be applied.
-          (defaults to latest,${CIRCLE_SHA1})
-        type: string
-        default: "latest,${CIRCLE_SHA1}"
-      eks_account_id:
-        description: |
-          Env var of the account id of the EKS cluster containing the deployment
-          (default EKS_ACCOUNT_ID)
-        type: env_var_name
-        default: EKS_ACCOUNT_ID
-      role_in_target_account:
-        description: |
-          Env var of the name of the role to be assumed to update the kubeconfig
-          (defaults to ASSUME_ROLE)
-        type: env_var_name
-        default: ASSUME_ROLE
-      aws_region:
-        description: |
-          Env var of AWS region to operate in
-          (defaults to AWS_REGION)
-        type: env_var_name
-        default: AWS_REGION
-      eks_cluster_name:
-        description: |
-          Env var of EKS cluster name
-          (defaults to EKS_NAME)
-        type: env_var_name
-        default: EKS_NAME
+      <<: *build-push-parameters
       deployment_name:
         description: Name of the deployment to restart
         type: string
@@ -177,39 +141,6 @@ jobs:
       k8s_namespace:
         description: Kubernetes namespace the deployment is located in
         type: string
-      dockerfile:
-        description: Dockerfile name
-        type: string
-        default: Dockerfile
-      path:
-        description: Path to the directory containing your Dockerfile.
-        type: string
-        default: .
-      build_path:
-        description: Path to the directory containing your build context.
-        type: string
-        default: .
-      extra_build_args:
-        description: Additional arguments to pass to the Docker build step
-        type: string
-        default: ""
-      attach_workspace:
-        type: boolean
-        default: true
-        description: >
-          Boolean for whether or not to attach to an existing workspace. Default
-          is true.
-      workspace_root:
-        type: string
-        default: "."
-        description: >
-          Workspace root path that is either an absolute path or a path relative
-          to the working directory. Defaults to '.' (the working directory)
-      platform:
-        type: string
-        default: "linux/amd64"
-        description: >
-          String to specify the architecture of the base image
     machine:
       image: ubuntu-2204:current
     steps:
@@ -290,7 +221,6 @@ examples:
             - build-push-restart:
                 context: ecr
                 repo: myecrrepo
-                deployment_name: mydeployment
 
   build-push-restart-staging:
     description:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -217,8 +217,8 @@ examples:
         version: 2
         aws-ecr-eks:
           jobs:
-            - build-push-restart:
-                context: ecr
+            - build-push:
+                context: ECR
                 repo: myecrrepo
 
   build-push-restart-staging:
@@ -232,6 +232,6 @@ examples:
         aws-ecr-eks:
           jobs:
             - build-push-restart:
-                context: ecr
+                context: ECR
                 repo: myecrrepo
                 deployment_name: mydeployment


### PR DESCRIPTION
Add a build-push job to the orb which can be used just like the existing build-push-restart job but which does not restart any pods of a k8s deployment.

This is useful as consumers of the orb may use this orb and the circleci/aws-ecr orb in the same circleci configuration, leading to extra configuration and maintenance effort.

Both jobs tested in consumer repo here: https://app.circleci.com/pipelines/github/signavio/jm-metrics/2435