### PR TITLE
[semver:minor] SIGPEX-42333: Do not install jq to fix build-push-restart job

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -383,7 +383,6 @@ jobs:
             sudo wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
             sudo chmod +x ./kubectl
             sudo cp ./kubectl /bin/kubectl
-            sudo apt-get update && sudo apt-get install -y jq
       - when: # NON_OIDC - Restart the deployment directly from the pipeline session
           condition:
             equal:


### PR DESCRIPTION
The install-tools started to fail on July 21st 2025, due to issues restarting services. 

I tested with pex-backend (by inlining build-push-restart job ([PR](https://github.com/signavio/pex-backend/pull/3372)) that jq is already installed on the default executor `ubuntu-2204:current`. Therefore I removed the line, which fixed the issue.  
