### PR TITLE
[semver:minor] Add push_image parameter

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -63,6 +63,12 @@ jobs:
         description: Additional arguments to pass to the Docker build step
         type: string
         default: ""
+      push_image:
+        type: boolean
+        default: true
+        description: >
+          Set to false to build an image without pushing to repository. Defaults
+          is true.
       attach_workspace:
         type: boolean
         default: true
@@ -179,6 +185,7 @@ jobs:
                 tag: <<parameters.tag>>
                 dockerfile: <<parameters.dockerfile>>
                 extra_build_args: <<parameters.extra_build_args>>
+                push_image: <<parameters.push_image>>
                 platform: <<parameters.platform>>
       - when: # OIDC - Build and Push image through the OIDC cross account approach
           condition:
@@ -200,6 +207,7 @@ jobs:
                 tag: <<parameters.tag>>
                 dockerfile: <<parameters.dockerfile>>
                 extra_build_args: <<parameters.extra_build_args>>
+                push_image: <<parameters.push_image>>
                 platform: <<parameters.platform>>
   #-----
   build-push-restart:


### PR DESCRIPTION
Adds `push_image` parameter which is passed to `aws-ecr` orb (only for `build-push` job).

---

# Use case

Trivy scan image without actually needing to have image in the repository.

- saving time to push
	- faster CI workflows
- less unused images in repository

```yaml
workflows:
  myworkflow:
    jobs:
      - aws-ecr-eks/build-push:
        name: build-and-trivy-scan
        ecr_account_id: ECR_ACCOUNT_ID_PROD
        ecr_role_name: ECR_ROLE_PROD
        assume_role_with_web_identity_enabled: true
        context:
          - ECR_OIDC
        repo: myrepository
        tag: $CIRCLE_SHA1
        push_image: false
        post-steps:
          - trivy/vulnerability-scan:
            docker-image: ${AWS_ECR_ACCOUNT_URL}/myrepository:$CIRCLE_SHA1
```

# Examples

- default `push_image` (`true`) https://app.circleci.com/pipelines/github/signavio/pi-etl-bridge-v2/3586/workflows/1e87645a-03b1-4369-b75a-69500798c03d
- explicit `push_image: false` https://app.circleci.com/pipelines/github/signavio/pi-etl-bridge-v2/3583/workflows/e9ff0679-8646-4d1c-a9cd-00581328fd61